### PR TITLE
electron 0.35.0 added 'electron' module

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -1,6 +1,9 @@
 // LICENSE : MIT
 "use strict";
-var dialog = require('dialog');
+
+const electron = require('electron');
+const dialog = electron.dialog;
+
 var CONSUMER = {
     key: 'elj9OpeplSmpfA==',
     secret: '1hqDhJ2BfB6kozd/nHeLIW7WC/Y='

--- a/example/package.json
+++ b/example/package.json
@@ -9,7 +9,7 @@
   "author": "azu",
   "license": "MIT",
   "devDependencies": {
-    "electron-prebuilt": "^0.30.7"
+    "electron-prebuilt": "^0.36.7"
   },
   "dependencies": {
     "electron-authentication-hatena": "file:.."

--- a/src/AuthenticationHatena.js
+++ b/src/AuthenticationHatena.js
@@ -1,7 +1,7 @@
 // LICENSE : MIT
 "use strict";
 import assert from "assert";
-import BrowserWindow from 'browser-window'
+import {BrowserWindow} from 'electron';
 import {OAuth} from "oauth";
 import {buildScope} from "./hatenaOauth";
 // ref: https://github.com/kymmt90/blog/blob/76fe9265df6f55b13d6ecd2d33168464926259bd/hatena_oauth.md


### PR DESCRIPTION
electron 0.35.0 added 'electron' module.
[electron/releases/tag/v0.35.0](https://github.com/atom/electron/releases/tag/v0.35.0)

use `const dialog = require('electron').dialog;` instead of `var dialog = require('dialog');`
